### PR TITLE
feat: language globe dropdown + immediate word problem refresh on language change

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -69,18 +69,49 @@ body {
   z-index: 100;
 }
 
-.language-selector button {
-  display: block;
-  border: 0;
-  width: 30px;
-  height: 22.5px;
+.lang-toggle {
+  background: transparent;
+  border: none;
+  color: white;
+  font-size: 20px;
+  cursor: pointer;
+  padding: 0 14px;
+  height: 66px;
+  display: flex;
+  align-items: center;
   box-shadow: none;
-  border-radius: 0px;
-  z-index: 200;
+  border-radius: 0;
+  grid-column: unset;
 }
 
-.language-selector > div {
-  float: left;
+.lang-toggle:hover {
+  background: #4b6a78;
+}
+
+.lang-dropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: #3c5560;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+}
+
+.lang-dropdown button {
+  display: block;
+  border: 0;
+  width: 48px;
+  height: 36px;
+  cursor: pointer;
+  box-shadow: none;
+  border-radius: 0;
+  grid-column: unset;
+}
+
+.lang-dropdown button:hover {
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: -2px;
 }
 
 .content {
@@ -369,8 +400,9 @@ textarea {
     padding: 4px 3px;
   }
 
-  .language-selector button {
-    width: 28px;
-    height: 20px;
+  .lang-toggle {
+    font-size: 18px;
+    padding: 0 10px;
+    height: 58px;
   }
 }

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'react'
+import { Component, createRef } from 'react'
 import { withTranslation, WithTranslation } from 'react-i18next'
 
 interface Props extends WithTranslation {
@@ -8,6 +8,7 @@ interface Props extends WithTranslation {
 
 interface State {
   selected: string
+  langOpen: boolean
 }
 
 interface Link {
@@ -15,10 +16,18 @@ interface Link {
   menuTranslationKey: string
 }
 
+const LANGUAGES = [
+  { code: 'en', flagClass: 'fi-gb' },
+  { code: 'se', flagClass: 'fi-se' },
+  { code: 'cn', flagClass: 'fi-tw' },
+]
+
 class Menu extends Component<Props, State> {
+  private langRef = createRef<HTMLDivElement>()
+
   constructor(props: Props) {
     super(props)
-    this.state = { selected: this.props.selected }
+    this.state = { selected: this.props.selected, langOpen: false }
   }
 
   links: Link[] = [
@@ -30,6 +39,26 @@ class Menu extends Component<Props, State> {
     { menuId: 'word-problems', menuTranslationKey: 'Word Problems' },
     { menuId: 'game', menuTranslationKey: 'Game' }
   ]
+
+  componentDidUpdate(_prevProps: Props, prevState: State) {
+    if (this.state.langOpen !== prevState.langOpen) {
+      if (this.state.langOpen) {
+        document.addEventListener('click', this.handleOutsideClick)
+      } else {
+        document.removeEventListener('click', this.handleOutsideClick)
+      }
+    }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleOutsideClick)
+  }
+
+  handleOutsideClick = (e: MouseEvent) => {
+    if (this.langRef.current && !this.langRef.current.contains(e.target as Node)) {
+      this.setState({ langOpen: false })
+    }
+  }
 
   getMenuLinks = () => {
     return this.links.map((link) => (
@@ -55,33 +84,37 @@ class Menu extends Component<Props, State> {
     return this.state.selected === selected ? 'active' : ''
   }
 
+  changeLang = (code: string) => {
+    this.props.i18n.changeLanguage(code)
+    localStorage.setItem('i18nextLng', code)
+    this.setState({ langOpen: false })
+  }
+
   render() {
+    const { langOpen } = this.state
     return (
       <div className="menu">
-        <div className="language-selector">
-          <div className="column-1">
-            <button
-              className="fib fi-gb"
-              onClick={() => {
-                this.props.i18n.changeLanguage('en')
-                localStorage.setItem('i18nextLng', 'en')
-              }}
-            ></button>
-            <button
-              className="fib fi-se"
-              onClick={() => {
-                this.props.i18n.changeLanguage('se')
-                localStorage.setItem('i18nextLng', 'se')
-              }}
-            ></button>
-            <button
-              className="fib fi-tw"
-              onClick={() => {
-                this.props.i18n.changeLanguage('cn')
-                localStorage.setItem('i18nextLng', 'cn')
-              }}
-            ></button>
-          </div>
+        <div className="language-selector" ref={this.langRef}>
+          <button
+            className="lang-toggle"
+            onClick={() => this.setState({ langOpen: !langOpen })}
+            aria-label="Select language"
+            aria-expanded={langOpen}
+          >
+            🌐
+          </button>
+          {langOpen && (
+            <div className="lang-dropdown">
+              {LANGUAGES.map(({ code, flagClass }) => (
+                <button
+                  key={code}
+                  className={`fib ${flagClass}`}
+                  onClick={() => this.changeLang(code)}
+                  aria-label={code}
+                />
+              ))}
+            </div>
+          )}
         </div>
         <ul>{this.getMenuLinks()}</ul>
       </div>

--- a/src/components/word-problems.tsx
+++ b/src/components/word-problems.tsx
@@ -38,10 +38,12 @@ class WordProblems extends Component<Props, State> {
     this.problemsPerPageHandler = this.problemsPerPageHandler.bind(this)
   }
 
-  componentDidUpdate(prevProps: Props) {
-    if (prevProps.i18n.language !== this.props.i18n.language) {
-      this.refresh()
-    }
+  componentDidMount() {
+    this.props.i18n.on('languageChanged', this.refresh)
+  }
+
+  componentWillUnmount() {
+    this.props.i18n.off('languageChanged', this.refresh)
   }
 
   buildPages(
@@ -66,7 +68,7 @@ class WordProblems extends Component<Props, State> {
     return ops.length > 0 ? ops : ['+']
   }
 
-  refresh() {
+  refresh = () => {
     const { difficulty, pageCount, problemsPerPage } = this.state
     this.setState({
       pages: this.buildPages(


### PR DESCRIPTION
## Summary

- Replaces the three stacked flag buttons in the menu with a single 🌐 globe icon; clicking it opens a compact dropdown with the three language flags. Clicking outside or selecting a flag closes it.
- Fixes word problem texts not regenerating when the language is switched: `componentDidUpdate` was comparing `prevProps.i18n.language` vs `this.props.i18n.language`, but since `i18n` is a singleton mutated in-place, both references always pointed to the same updated value. Replaced with an `i18n.on('languageChanged', this.refresh)` event listener in `componentDidMount`/`componentWillUnmount`.

## Test plan

- [ ] Globe icon appears in the top-right corner of the menu
- [ ] Clicking the globe opens a dropdown with the GB, SE and TW flags
- [ ] Clicking a flag changes the language and closes the dropdown
- [ ] Clicking outside the dropdown closes it without changing language
- [ ] Navigating to Word Problems and switching language regenerates all problem texts immediately in the new language

🤖 Generated with [Claude Code](https://claude.com/claude-code)